### PR TITLE
Fix failing GitHub Actions tests (#30)

### DIFF
--- a/py_load_faers/cli.py
+++ b/py_load_faers/cli.py
@@ -97,7 +97,9 @@ def run(
         _, dq_message = engine.run_load(mode=mode, quarter=quarter)
         typer.secho(f"ETL process completed. {dq_message}", fg=typer.colors.GREEN)
     except Exception as e:
-        typer.secho(f"An error occurred during the ETL process: {e}", err=True, fg=typer.colors.RED)
+        typer.secho(
+            f"An error occurred during the ETL process: {e}", err=True, fg=typer.colors.RED
+        )
         raise typer.Exit(code=1)
     finally:
         if db_loader.conn:

--- a/py_load_faers/staging.py
+++ b/py_load_faers/staging.py
@@ -7,16 +7,13 @@ import logging
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Iterator, Dict, Any, Type, List, Optional
+from typing import Dict, Any, Type, List, Optional, Iterable
 from pydantic import BaseModel
 import polars as pl
 
 from .config import ProcessingSettings
 
 logger = logging.getLogger(__name__)
-
-
-from typing import Iterable
 
 
 def stage_data(


### PR DESCRIPTION
The GitHub Actions tests were failing due to a code formatting issue. The `black` code formatter needed to be run on the codebase.

This commit fixes the issue by:
- Running `poetry run black .` to format the code.
- Running `poetry run ruff check . --fix` and manually fixing linting errors.
- Running `poetry install` to ensure all dependencies are installed.