### PR TITLE
fix: Suppress mypy errors for untyped testcontainers library (#36)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,8 @@ line-length = 99
 
 [tool.ruff]
 line-length = 99
+
+[tool.mypy]
+[[tool.mypy.overrides]]
+module = "testcontainers.postgres"
+ignore_missing_imports = true


### PR DESCRIPTION
The `testcontainers` library does not have type stubs, which causes mypy to fail when running in strict mode.

This change adds a mypy override to `pyproject.toml` to ignore missing imports for `testcontainers.postgres`, resolving the CI build failure.